### PR TITLE
Add support for IDv3 and operator v2 APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ make install
 
 ```
 docker build . -t uid2_client_cpp
-# docker run -it uid2_client_cpp <base-url> <api-key> <advertising-token>
+# docker run -it uid2_client_cpp <base-url> <api-key> <secret-key> <advertising-token>
 # For example:
-docker run -it uid2_client_cpp https://integ.uidapi.com test-id-reader-key \
+docker run -it uid2_client_cpp https://integ.uidapi.com test-id-reader-key your-secret-key \
 	AgAAAANzUr8B6CCM+WBKichZGU8iyDBSI83LXiXa1SW2i4LaVQPzlBtOhjoeUUc3Nv+aOPLwiVol0rnxwdNkJNgm710I4lKAp8kpjqZO6evjN6mVZalwzQA5Y4usQVEtwBkYr3V3MbYR1eI3n0Bc7/KVeanfBXUF4odpHNBEWTAL+YgSCA==
 ```
 

--- a/app/example.cpp
+++ b/app/example.cpp
@@ -35,11 +35,11 @@ static void StartExample(const std::string& desc)
 	std::cout.flush();
 }
 
-static void ExampleBasic(const std::string& baseUrl, const std::string& apiKey, const std::string adToken)
+static void ExampleBasic(const std::string& baseUrl, const std::string& apiKey, const std::string& secretKey, const std::string adToken)
 {
 	StartExample("Basic keys refresh and decrypt token");
 
-	const auto client = UID2ClientFactory::Create(baseUrl, apiKey);
+	const auto client = UID2ClientFactory::Create(baseUrl, apiKey, secretKey);
 	const auto refreshResult = client->Refresh();
 	if (!refreshResult.IsSuccess())
 	{
@@ -51,13 +51,14 @@ static void ExampleBasic(const std::string& baseUrl, const std::string& apiKey, 
 	std::cout << "DecryptedSuccess=" << result.IsSuccess() << " Status=" << (int)result.GetStatus() << "\n";
 	std::cout << "UID=" << result.GetUid() << "\n";
 	std::cout << "EstablishedAt=" << result.GetEstablished().GetEpochSecond() << "\n";
+    std::cout << "SiteId=" << result.GetSiteId() << "\n";
 }
 
-static void ExampleAutoRefresh(const std::string& baseUrl, const std::string& apiKey, const std::string adToken)
+static void ExampleAutoRefresh(const std::string& baseUrl, const std::string& apiKey, const std::string& secretKey, const std::string adToken)
 {
 	StartExample("Automatic background keys refresh");
 
-	const auto client = UID2ClientFactory::Create(baseUrl, apiKey);
+	const auto client = UID2ClientFactory::Create(baseUrl, apiKey, secretKey);
 	std::thread refreshThread([&]
 		{
 			for(int i = 0; i < 8; ++i)
@@ -80,11 +81,11 @@ static void ExampleAutoRefresh(const std::string& baseUrl, const std::string& ap
 	refreshThread.join();
 }
 
-static void ExampleEncryptDecryptData(const std::string& baseUrl, const std::string& apiKey, const std::string adToken)
+static void ExampleEncryptDecryptData(const std::string& baseUrl, const std::string& apiKey, const std::string& secretKey, const std::string adToken)
 {
 	StartExample("Encrypt and Decrypt Data");
 
-	const auto client = UID2ClientFactory::Create(baseUrl, apiKey);
+	const auto client = UID2ClientFactory::Create(baseUrl, apiKey, secretKey);
 	const auto refreshResult = client->Refresh();
 	if (!refreshResult.IsSuccess())
 	{
@@ -119,19 +120,20 @@ static void ExampleEncryptDecryptData(const std::string& baseUrl, const std::str
 
 int main(int argc, char** argv)
 {
-	if(argc < 4)
+	if(argc < 5)
 	{
-		std::cerr << "Usage: example <base-url> <api-key> <ad-token>" << std::endl;
+		std::cerr << "Usage: example <base-url> <api-key> <secret-key> <ad-token>" << std::endl;
 		return 1;
 	}
 
 	const std::string baseUrl = argv[1];
 	const std::string apiKey = argv[2];
-	const std::string adToken = argv[3];
+    const std::string secretKey = argv[3];
+	const std::string adToken = argv[4];
 
-	ExampleBasic(baseUrl, apiKey, adToken);
-	ExampleAutoRefresh(baseUrl, apiKey, adToken);
-	ExampleEncryptDecryptData(baseUrl, apiKey, adToken);
+	ExampleBasic(baseUrl, apiKey, secretKey, adToken);
+	ExampleAutoRefresh(baseUrl, apiKey, secretKey, adToken);
+	ExampleEncryptDecryptData(baseUrl, apiKey, secretKey, adToken);
 
 	return 0;
 }

--- a/include/uid2/types.h
+++ b/include/uid2/types.h
@@ -33,6 +33,18 @@ namespace uid2
 {
 	struct Key;
 
+    enum class IdentityScope
+    {
+        UID2 = 0,
+        EUID = 1,
+    };
+
+    enum class IdentityType
+    {
+        Email = 0,
+        Phone = 1,
+    };
+
 	enum class DecryptionStatus
 	{
 		SUCCESS,
@@ -43,6 +55,7 @@ namespace uid2
 		KEYS_NOT_SYNCED,
 		VERSION_NOT_SUPPORTED,
 		INVALID_PAYLOAD_TYPE,
+        INVALID_IDENTITY_SCOPE,
 	};
 
 	enum class EncryptionStatus
@@ -84,6 +97,10 @@ namespace uid2
 		{
 			return DecryptionResult(status, std::string(), Timestamp(), -1);
 		}
+        static DecryptionResult MakeError(DecryptionStatus status, Timestamp established, int siteId)
+        {
+            return DecryptionResult(status, std::string(), established, siteId);
+        }
 
 		bool IsSuccess() const { return Status == DecryptionStatus::SUCCESS; }
 		DecryptionStatus GetStatus() const { return Status; }

--- a/include/uid2/uid2client.h
+++ b/include/uid2/uid2client.h
@@ -46,7 +46,7 @@ namespace uid2
 	class UID2Client : public IUID2Client
 	{
 	public:
-		UID2Client(std::string endpoint, std::string authKey);
+		UID2Client(std::string endpoint, std::string authKey, std::string secretKey, IdentityScope identityScope);
 		~UID2Client();
 
 		RefreshResult Refresh() override;
@@ -70,9 +70,18 @@ namespace uid2
 	class UID2ClientFactory
 	{
 	public:
-		static std::shared_ptr<IUID2Client> Create(std::string endpoint, std::string authKey)
+		static std::shared_ptr<IUID2Client> Create(std::string endpoint, std::string authKey, std::string secretKey)
 		{
-			return std::make_shared<UID2Client>(endpoint, authKey);
+			return std::make_shared<UID2Client>(endpoint, authKey, secretKey, IdentityScope::UID2);
 		}
 	};
+
+    class EUIDClientFactory
+    {
+    public:
+        static std::shared_ptr<IUID2Client> Create(std::string endpoint, std::string authKey, std::string secretKey)
+        {
+            return std::make_shared<UID2Client>(endpoint, authKey, secretKey, IdentityScope::EUID);
+        }
+    };
 }

--- a/lib/bigendianprocessor.h
+++ b/lib/bigendianprocessor.h
@@ -44,7 +44,11 @@ namespace uid2
 		BigEndianByteReader(const BigEndianByteReader&) = delete;
 		BigEndianByteReader& operator=(const BigEndianByteReader&) = delete;
 
-		uint8_t ReadByte()
+        int GetPosition() const { return position; }
+        int GetRemainingSize() const { return size - position; }
+        const std::uint8_t* GetCurrentData() const { return bytes + GetPosition(); }
+
+        uint8_t ReadByte()
 		{
 			CheckCanRead(1);
 			return bytes[position++];

--- a/lib/uid2encryption.cpp
+++ b/lib/uid2encryption.cpp
@@ -446,7 +446,7 @@ namespace uid2
         }
         totalLen += outLen;
 
-        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_GET_TAG, GCM_AUTHTAG_LENGTH, out_encrypted + totalLen)) {
+        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_GET_TAG, GCM_AUTHTAG_LENGTH, out_encrypted + totalLen)) {
             throw std::runtime_error("failed to get tag");
         }
         totalLen += GCM_AUTHTAG_LENGTH;
@@ -477,7 +477,7 @@ namespace uid2
         }
         const int totalLen = outLen;
 
-        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, GCM_AUTHTAG_LENGTH, (void*)(encrypted + (size - GCM_AUTHTAG_LENGTH))))
+        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_TAG, GCM_AUTHTAG_LENGTH, (void*)(encrypted + (size - GCM_AUTHTAG_LENGTH))))
         {
             throw std::runtime_error("failed to set auth tag for decrypt");
         }

--- a/lib/uid2encryption.cpp
+++ b/lib/uid2encryption.cpp
@@ -51,9 +51,6 @@ namespace uid2
     static const int GCM_AUTHTAG_LENGTH = 16;
     static const int GCM_IV_LENGTH = 12;
 
-	static const std::uint8_t* GenerateIv(std::uint8_t* iv);
-	static std::vector<std::uint8_t> AddPadding(const std::uint8_t* data, int size);
-	static void Encrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted);
 	static void Decrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::vector<std::uint8_t>& out_decrypted);
     static int EncryptGCM(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted);
 
@@ -375,21 +372,6 @@ namespace uid2
 
         return DecryptionDataResult::MakeSuccess({payloadReader.GetCurrentData(), payloadReader.GetCurrentData() + payloadReader.GetRemainingSize()}, encryptedAt);
     }
-
-	const std::uint8_t* GenerateIv(std::uint8_t* iv)
-	{
-		const int rc = RAND_bytes(iv, BLOCK_SIZE);
-		if (rc <= 0)
-		{
-			throw std::runtime_error("failed to generate secure random bytes: " + std::to_string(ERR_get_error()));
-		}
-		return iv;
-	}
-
-	void Encrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted)
-	{
-		AES256().EncryptCBC(data, size, secret, iv, out_encrypted);
-	}
 
 	void Decrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::vector<std::uint8_t>& out_decrypted)
 	{

--- a/lib/uid2encryption.cpp
+++ b/lib/uid2encryption.cpp
@@ -27,10 +27,12 @@
 #include "base64.h"
 #include "bigendianprocessor.h"
 
+#include <memory>
 #include <stdexcept>
 #include <unordered_map>
 
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
 
 namespace uid2
@@ -43,20 +45,30 @@ namespace uid2
 	enum class PayloadType : std::uint8_t
 	{
 		ENCRYPTED_DATA = 128,
-	};
+        ENCRYPTED_DATA_V3 = 96,
+    };
+
+    static const int GCM_AUTHTAG_LENGTH = 16;
+    static const int GCM_IV_LENGTH = 12;
 
 	static const std::uint8_t* GenerateIv(std::uint8_t* iv);
 	static std::vector<std::uint8_t> AddPadding(const std::uint8_t* data, int size);
 	static void Encrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted);
 	static void Decrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::vector<std::uint8_t>& out_decrypted);
+    static int EncryptGCM(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted);
 
-	DecryptionResult DecryptToken(const std::string& token, const KeyContainer& keys, Timestamp now, bool checkValidity)
+    static IdentityScope DecodeIdentityScopeV3(std::uint8_t value);
+
+    static DecryptionResult DecryptTokenV2(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, bool checkValidity);
+    static DecryptionResult DecryptTokenV3(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, IdentityScope identityScope, bool checkValidity);
+
+    DecryptionResult DecryptToken(const std::string& token, const KeyContainer& keys, Timestamp now, IdentityScope identityScope, bool checkValidity)
 	{
 		try
 		{
 			std::vector<std::uint8_t> encodedId;
 			macaron::Base64::Decode(token, encodedId);
-			return DecryptToken(encodedId, keys, now, checkValidity);
+			return DecryptToken(encodedId, keys, now, identityScope, checkValidity);
 		}
 		catch (...)
 		{
@@ -64,8 +76,27 @@ namespace uid2
 		}
 	}
 
-	DecryptionResult DecryptToken(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, bool checkValidity)
-	{
+	DecryptionResult DecryptToken(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, IdentityScope identityScope, bool checkValidity)
+    {
+        if (encryptedId.size() < 2)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::INVALID_PAYLOAD);
+        }
+
+        if (encryptedId[0] == 2)
+        {
+            return DecryptTokenV2(encryptedId, keys, now, checkValidity);
+        }
+        else if (encryptedId[1] == 112)
+        {
+            return DecryptTokenV3(encryptedId, keys, now, identityScope, checkValidity);
+        }
+
+        return DecryptionResult::MakeError(DecryptionStatus::VERSION_NOT_SUPPORTED);
+    }
+
+    static DecryptionResult DecryptTokenV2(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, bool checkValidity)
+    {
 		BigEndianByteReader reader(encryptedId);
 
 		const int version = (int)reader.ReadByte();
@@ -91,14 +122,6 @@ namespace uid2
 		BigEndianByteReader masterPayloadReader(masterDecrypted);
 
 		const Timestamp expires = Timestamp::FromEpochMilli(masterPayloadReader.ReadInt64());
-		if (checkValidity)
-		{
-			if (expires < now)
-			{
-				return DecryptionResult::MakeError(DecryptionStatus::EXPIRED_TOKEN);
-			}
-		}
-
 		const int siteKeyId = masterPayloadReader.ReadInt32();
 		const auto siteKey = keys.Get(siteKeyId);
 		if (siteKey == nullptr)
@@ -122,10 +145,86 @@ namespace uid2
 		const std::int32_t privacyBits = identityPayloadReader.ReadInt32();
 		const Timestamp established = Timestamp::FromEpochMilli(identityPayloadReader.ReadInt64());
 
-		return DecryptionResult::MakeSuccess(std::move(idString), established, siteId);
+        if (checkValidity && expires < now)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::EXPIRED_TOKEN, established, siteId);
+        }
+
+        return DecryptionResult::MakeSuccess(std::move(idString), established, siteId);
 	}
 
-	EncryptionDataResult EncryptData(const EncryptionDataRequest& req, const KeyContainer* keys)
+    static DecryptionResult DecryptTokenV3(const std::vector<std::uint8_t>& encryptedId, const KeyContainer& keys, Timestamp now, IdentityScope identityScope, bool checkValidity)
+    {
+        BigEndianByteReader reader(encryptedId);
+
+        const auto prefix = reader.ReadByte();
+        if (DecodeIdentityScopeV3(prefix) != identityScope)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::INVALID_IDENTITY_SCOPE);
+        }
+
+        const auto version = reader.ReadByte();
+
+        const std::int32_t masterKeyId = reader.ReadInt32();
+        const auto masterKey = keys.Get(masterKeyId);
+        if (masterKey == nullptr)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::NOT_AUTHORIZED_FOR_KEY);
+        }
+
+        std::uint8_t masterPayload[256];
+        if (reader.GetRemainingSize() > sizeof(masterPayload))
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::INVALID_PAYLOAD);
+        }
+        const int masterPayloadLen = DecryptGCM(reader.GetCurrentData(), reader.GetRemainingSize(), masterKey->secret.data(), masterPayload);
+
+        BigEndianByteReader masterPayloadReader(masterPayload, masterPayloadLen);
+
+        const Timestamp expires = Timestamp::FromEpochMilli(masterPayloadReader.ReadInt64());
+        const Timestamp created = Timestamp::FromEpochMilli(masterPayloadReader.ReadInt64());
+
+        const auto operatorSiteId = masterPayloadReader.ReadInt32();
+        const auto operatorType = masterPayloadReader.ReadByte();
+        const auto operatorVersion = masterPayloadReader.ReadInt32();
+        const auto operatorClientKeyId = masterPayloadReader.ReadInt32();
+
+        const auto siteKeyId = masterPayloadReader.ReadInt32();
+        const auto siteKey = keys.Get(siteKeyId);
+        if (siteKey == nullptr)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::NOT_AUTHORIZED_FOR_KEY);
+        }
+
+        std::uint8_t sitePayload[128];
+        if (masterPayloadReader.GetRemainingSize() > sizeof(sitePayload))
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::INVALID_PAYLOAD);
+        }
+        const auto sitePayloadLen = DecryptGCM(masterPayloadReader.GetCurrentData(), masterPayloadReader.GetRemainingSize(), siteKey->secret.data(), sitePayload);
+
+        BigEndianByteReader sitePayloadReader(sitePayload, sitePayloadLen);
+
+        const auto siteId = sitePayloadReader.ReadInt32();
+        const auto publisherId = sitePayloadReader.ReadInt64();
+        const auto publisherKeyId = sitePayloadReader.ReadInt32();
+
+        const auto privacyBits = sitePayloadReader.ReadInt32();
+        const Timestamp established = Timestamp::FromEpochMilli(sitePayloadReader.ReadInt64());
+        const Timestamp refreshed = Timestamp::FromEpochMilli(sitePayloadReader.ReadInt64());
+
+        if (checkValidity && expires < now)
+        {
+            return DecryptionResult::MakeError(DecryptionStatus::EXPIRED_TOKEN, established, siteId);
+        }
+
+        const std::vector<std::uint8_t> identityBytes(sitePayloadReader.GetCurrentData(), sitePayloadReader.GetCurrentData() + sitePayloadReader.GetRemainingSize());
+        auto idString = macaron::Base64::Encode(identityBytes);
+
+        return DecryptionResult::MakeSuccess(std::move(idString), established, siteId);
+    }
+
+    EncryptionDataResult EncryptData(const EncryptionDataRequest& req, const KeyContainer* keys, IdentityScope identityScope)
 	{
 		if (req.GetData() == nullptr) throw std::invalid_argument("data to encrypt must not be null");
 
@@ -152,7 +251,7 @@ namespace uid2
 			}
 			else
 			{
-				const auto decryptedToken = DecryptToken(req.GetAdvertisingToken(), *keys, now, true);
+				const auto decryptedToken = DecryptToken(req.GetAdvertisingToken(), *keys, now, identityScope, true);
 				if (!decryptedToken.IsSuccess())
 				{
 					return EncryptionDataResult::MakeError(EncryptionStatus::TOKEN_DECRYPT_FAILURE);
@@ -176,32 +275,49 @@ namespace uid2
 		}
 
 		const std::uint8_t* iv = req.GetInitializationVector();
-		std::uint8_t localIv[BLOCK_SIZE];
-		if (iv == nullptr)
+		if (iv != nullptr && req.GetInitializationVectorSize() != GCM_IV_LENGTH)
 		{
-			iv = GenerateIv(localIv);
-		}
-		else if (req.GetInitializationVectorSize() != BLOCK_SIZE)
-		{
-			throw std::invalid_argument("initialization vector size must be " + std::to_string(BLOCK_SIZE));
+			throw std::invalid_argument("initialization vector size must be " + std::to_string(GCM_IV_LENGTH));
 		}
 
-		const auto paddedData = AddPadding(req.GetData(), req.GetDataSize());
-		std::vector<std::uint8_t> encryptedBuffer(paddedData.size() + 34);
-		BigEndianByteWriter writer(encryptedBuffer.data(), encryptedBuffer.size());
-		writer.WriteByte((std::uint8_t)PayloadType::ENCRYPTED_DATA);
-		writer.WriteByte(1); // version
-		writer.WriteInt64(now.GetEpochMilli());
-		writer.WriteInt32(siteId);
-		writer.WriteInt32(key->id);
-		writer.WriteBytes(iv, 0, BLOCK_SIZE);
-		Encrypt(paddedData.data(), paddedData.size(), iv, key->secret.data(), &encryptedBuffer[writer.GetPosition()]);
+		std::vector<std::uint8_t> payload(req.GetDataSize() + 12);
+        BigEndianByteWriter payloadWriter(payload);
+        payloadWriter.WriteInt64(now.GetEpochMilli());
+        payloadWriter.WriteInt32(siteId);
+        payloadWriter.WriteBytes(req.GetData(), 0, req.GetDataSize());
 
-		return EncryptionDataResult::MakeSuccess(macaron::Base64::Encode(encryptedBuffer));
+        std::vector<std::uint8_t> encryptedBytes(payload.size() + GCM_IV_LENGTH + GCM_AUTHTAG_LENGTH + 6);
+        BigEndianByteWriter writer(encryptedBytes);
+        writer.WriteByte((std::uint8_t)PayloadType::ENCRYPTED_DATA_V3 | ((std::uint8_t)identityScope << 4) | 0xB);
+        writer.WriteByte((std::uint8_t)112); // version
+        writer.WriteInt32(key->id);
+        EncryptGCM(payload.data(), payload.size(), iv, key->secret.data(), encryptedBytes.data() + writer.GetPosition());
+
+		return EncryptionDataResult::MakeSuccess(macaron::Base64::Encode(encryptedBytes));
 	}
 
-    DecryptionDataResult DecryptData(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys)
+    static DecryptionDataResult DecryptDataV2(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys);
+    static DecryptionDataResult DecryptDataV3(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys, IdentityScope identityScope);
+
+    DecryptionDataResult DecryptData(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys, IdentityScope identityScope)
 	{
+        if (encryptedBytes.empty())
+        {
+            return DecryptionDataResult::MakeError(DecryptionStatus::INVALID_PAYLOAD);
+        }
+
+        if ((encryptedBytes[0] & 224) == (std::uint8_t)PayloadType::ENCRYPTED_DATA_V3)
+        {
+            return DecryptDataV3(encryptedBytes, keys, identityScope);
+        }
+        else
+        {
+            return DecryptDataV2(encryptedBytes, keys);
+        }
+    }
+
+    static DecryptionDataResult DecryptDataV2(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys)
+    {
 		BigEndianByteReader reader(encryptedBytes);
 
 		if (reader.ReadByte() != (std::uint8_t)PayloadType::ENCRYPTED_DATA)
@@ -230,6 +346,36 @@ namespace uid2
 		return DecryptionDataResult::MakeSuccess(std::move(decryptedBytes), encryptedAt);
 	}
 
+    static DecryptionDataResult DecryptDataV3(const std::vector<std::uint8_t>& encryptedBytes, const KeyContainer& keys, IdentityScope identityScope)
+    {
+        BigEndianByteReader reader(encryptedBytes);
+        const auto payloadScope = DecodeIdentityScopeV3(reader.ReadByte());
+        if (payloadScope != identityScope)
+        {
+            return DecryptionDataResult::MakeError(DecryptionStatus::INVALID_IDENTITY_SCOPE);
+        }
+        if (reader.ReadByte() != 112)
+        {
+            return DecryptionDataResult::MakeError(DecryptionStatus::VERSION_NOT_SUPPORTED);
+        }
+
+        const auto keyId = reader.ReadInt32();
+        const auto key = keys.Get(keyId);
+        if (key == nullptr)
+        {
+            return DecryptionDataResult::MakeError(DecryptionStatus::NOT_AUTHORIZED_FOR_KEY);
+        }
+
+        std::vector<std::uint8_t> payload(reader.GetRemainingSize());
+        const auto payloadLen = DecryptGCM(reader.GetCurrentData(), reader.GetRemainingSize(), key->secret.data(), payload.data());
+
+        BigEndianByteReader payloadReader(payload.data(), payloadLen);
+        const auto encryptedAt = Timestamp::FromEpochMilli(payloadReader.ReadInt64());
+        const int siteId = payloadReader.ReadInt32();
+
+        return DecryptionDataResult::MakeSuccess({payloadReader.GetCurrentData(), payloadReader.GetCurrentData() + payloadReader.GetRemainingSize()}, encryptedAt);
+    }
+
 	const std::uint8_t* GenerateIv(std::uint8_t* iv)
 	{
 		const int rc = RAND_bytes(iv, BLOCK_SIZE);
@@ -238,16 +384,6 @@ namespace uid2
 			throw std::runtime_error("failed to generate secure random bytes: " + std::to_string(ERR_get_error()));
 		}
 		return iv;
-	}
-
-	std::vector<std::uint8_t> AddPadding(const std::uint8_t* data, int size)
-	{
-		const int padlen = BLOCK_SIZE - (size % BLOCK_SIZE);
-		std::vector<std::uint8_t> result;
-		result.reserve(size + padlen);
-		result.insert(result.begin(), data, data + size);
-		result.insert(result.end(), (std::size_t)padlen, (std::uint8_t)padlen);
-		return result;
 	}
 
 	void Encrypt(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted)
@@ -268,4 +404,112 @@ namespace uid2
 		out_decrypted.resize(size - padlen);
 	}
 
+    template<typename T, typename D>
+    using CleanupPtr = std::unique_ptr<T, D>;
+    template<typename T, typename D>
+    CleanupPtr<T, D> MakeCleanupPtr(T* ptr, D deleter)
+    {
+        return CleanupPtr<T, D>(ptr, deleter);
+    }
+
+    void RandomBytes(std::uint8_t* out, int count)
+    {
+        const int rc = RAND_bytes(out, count);
+        if (rc <= 0)
+        {
+            throw std::runtime_error("failed to generate random bytes: " + std::to_string(ERR_get_error()));
+        }
+    }
+
+    int EncryptGCM(const std::uint8_t* data, int size, const std::uint8_t* secret, std::uint8_t* out_encrypted)
+    {
+        return EncryptGCM(data, size, nullptr, secret, out_encrypted);
+    }
+
+    static int EncryptGCM(const std::uint8_t* data, int size, const std::uint8_t* iv, const std::uint8_t* secret, std::uint8_t* out_encrypted)
+    {
+        int totalLen = 0;
+        if (iv == nullptr)
+        {
+            const int rc = RAND_bytes(out_encrypted, GCM_IV_LENGTH);
+            if (rc <= 0) {
+                throw std::runtime_error("failed to generate iv: " + std::to_string(ERR_get_error()));
+            }
+        }
+        else
+        {
+            std::memcpy(out_encrypted, iv, GCM_IV_LENGTH);
+        }
+        totalLen += GCM_IV_LENGTH;
+
+        auto ctx = MakeCleanupPtr(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+        if (!ctx) {
+            throw std::runtime_error("failed to allocate new cipher context");
+        }
+
+        if (!EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_gcm(), nullptr, secret, out_encrypted)) {
+            throw std::runtime_error("failed to init encryption");
+        }
+
+        int outLen = 0;
+        if (!EVP_EncryptUpdate(ctx.get(), out_encrypted + totalLen, &outLen, data, size))
+        {
+            throw std::runtime_error("failed to encrypt");
+        }
+        totalLen += outLen;
+
+        if (!EVP_EncryptFinal_ex(ctx.get(), out_encrypted + totalLen, &outLen))
+        {
+            throw std::runtime_error("failed to finalize encrypt");
+        }
+        totalLen += outLen;
+
+        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_GET_TAG, GCM_AUTHTAG_LENGTH, out_encrypted + totalLen)) {
+            throw std::runtime_error("failed to get tag");
+        }
+        totalLen += GCM_AUTHTAG_LENGTH;
+
+        return totalLen;
+    }
+
+    int DecryptGCM(const std::uint8_t* encrypted, int size, const std::uint8_t* secret, std::uint8_t* out_decrypted)
+    {
+        if (size < GCM_IV_LENGTH + GCM_AUTHTAG_LENGTH)
+        {
+            throw std::runtime_error("invalid ciphertext");
+        }
+
+        auto ctx = MakeCleanupPtr(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+        if (!ctx) {
+            throw std::runtime_error("failed to allocate new cipher context");
+        }
+
+        if (!EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_gcm(), nullptr, secret, encrypted)) {
+            throw std::runtime_error("failed to init decryption");
+        }
+
+        int outLen = 0;
+        if (!EVP_DecryptUpdate(ctx.get(), out_decrypted, &outLen, encrypted + GCM_IV_LENGTH, size - (GCM_IV_LENGTH + GCM_AUTHTAG_LENGTH)))
+        {
+            throw std::runtime_error("failed to decrypt");
+        }
+        const int totalLen = outLen;
+
+        if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, GCM_AUTHTAG_LENGTH, (void*)(encrypted + (size - GCM_AUTHTAG_LENGTH))))
+        {
+            throw std::runtime_error("failed to set auth tag for decrypt");
+        }
+
+        if (0 >= EVP_DecryptFinal_ex(ctx.get(), out_decrypted, &outLen))
+        {
+            throw std::runtime_error("auth data check failed");
+        }
+
+        return totalLen;
+    }
+
+    static IdentityScope DecodeIdentityScopeV3(std::uint8_t value)
+    {
+        return (IdentityScope)((value >> 4) & 1);
+    }
 }

--- a/lib/uid2encryption.h
+++ b/lib/uid2encryption.h
@@ -37,18 +37,27 @@ namespace uid2
 		const std::string& token,
 		const KeyContainer& keys,
 		Timestamp now,
+        IdentityScope identityScope,
 		bool checkValidity);
 	DecryptionResult DecryptToken(
 		const std::vector<std::uint8_t>& encryptedId,
 		const KeyContainer& keys,
 		Timestamp now,
+        IdentityScope identityScope,
 		bool checkValidity);
 
 	EncryptionDataResult EncryptData(
 		const EncryptionDataRequest& req,
-		const KeyContainer* keys);
+		const KeyContainer* keys,
+        IdentityScope identityScope);
 
 	DecryptionDataResult DecryptData(
 		const std::vector<std::uint8_t>& encryptedBytes,
-		const KeyContainer& keys);
+		const KeyContainer& keys,
+        IdentityScope identityScope);
+
+    void RandomBytes(std::uint8_t* out, int count);
+
+    int EncryptGCM(const std::uint8_t* data, int size, const std::uint8_t* secret, std::uint8_t* out_encrypted);
+    int DecryptGCM(const std::uint8_t* encrypted, int size, const std::uint8_t* secret, std::uint8_t* out_decrypted);
 }

--- a/test/keygen.h
+++ b/test/keygen.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <uid2/types.h>
+
 #include "key.h"
 
 #include <string>
@@ -33,6 +35,11 @@ struct EncryptTokenParams
 	EncryptTokenParams& WithTokenExpiry(uid2::Timestamp expiry) { tokenExpiry = expiry; return *this; }
 
 	uid2::Timestamp tokenExpiry = uid2::Timestamp::Now().AddSeconds(60);
+    uid2::IdentityScope identityScope = uid2::IdentityScope::UID2;
+    uid2::IdentityType identityType = uid2::IdentityType::Email;
 };
 
-std::string EncryptToken(const std::string& identity, const uid2::Key& masterKey, int siteId, const uid2::Key& siteKey, EncryptTokenParams params = EncryptTokenParams());
+std::string EncryptTokenV2(const std::string& identity, const uid2::Key& masterKey, int siteId, const uid2::Key& siteKey, EncryptTokenParams params = EncryptTokenParams());
+std::string EncryptTokenV3(const std::string& identity, const uid2::Key& masterKey, int siteId, const uid2::Key& siteKey, EncryptTokenParams params = EncryptTokenParams());
+
+std::string EncryptDataV2(const std::vector<std::uint8_t>& data, const uid2::Key& key, int siteId, uid2::Timestamp now);

--- a/test/test_decryption_v2.cpp
+++ b/test/test_decryption_v2.cpp
@@ -1,0 +1,245 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <uid2/uid2client.h>
+
+#include "base64.h"
+#include "key.h"
+#include "keygen.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+using namespace uid2;
+
+static std::vector<std::uint8_t> GetMasterSecret();
+static std::vector<std::uint8_t> GetSiteSecret();
+static std::vector<std::uint8_t> MakeKeySecret(std::uint8_t v);
+static std::string KeySetToJson(const std::vector<Key>& keys);
+static std::vector<std::uint8_t> Base64Decode(const std::string& str);
+
+static const std::int64_t MASTER_KEY_ID = 164;
+static const std::int64_t SITE_KEY_ID = 165;
+static const int SITE_ID = 9000;
+static const std::uint8_t MASTER_SECRET[] = { 139, 37, 241, 173, 18, 92, 36, 232, 165, 168, 23, 18, 38, 195, 123, 92, 160, 136, 185, 40, 91, 173, 165, 221, 168, 16, 169, 164, 38, 139, 8, 155 };
+static const std::uint8_t SITE_SECRET[] = { 32, 251, 7, 194, 132, 154, 250, 86, 202, 116, 104, 29, 131, 192, 139, 215, 48, 164, 11, 65, 226, 110, 167, 14, 108, 51, 254, 125, 65, 24, 23, 133 };
+static const Timestamp NOW = Timestamp::Now();
+static const Key MASTER_KEY{MASTER_KEY_ID, -1, NOW.AddDays(-1), NOW, NOW.AddDays(1), GetMasterSecret()};
+static const Key SITE_KEY{SITE_KEY_ID, SITE_ID, NOW.AddDays(-10), NOW.AddDays(-9), NOW.AddDays(1), GetSiteSecret()};
+static const std::string EXAMPLE_UID = "ywsvDNINiZOVSsfkHpLpSJzXzhr6Jx9Z/4Q0+lsEUvM=";
+static const std::string CLIENT_SECRET = "ioG3wKxAokmp+rERx6A4kM/13qhyolUXIu14WN16Spo=";
+
+TEST(DecryptionTestsV2, SmokeTest)
+{
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({MASTER_KEY, SITE_KEY}));
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+    const auto res = client.Decrypt(advertisingToken, Timestamp::Now());
+    EXPECT_TRUE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::SUCCESS, res.GetStatus());
+    EXPECT_EQ(EXAMPLE_UID, res.GetUid());
+}
+
+TEST(DecryptionTestsV2, EmptyKeyContainer)
+{
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+    const auto res = client.Decrypt(advertisingToken, Timestamp::Now());
+    EXPECT_FALSE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::NOT_INITIALIZED, res.GetStatus());
+}
+
+TEST(DecryptionTestsV2, ExpiredKeyContainer)
+{
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+
+    const Key masterKeyExpired{MASTER_KEY_ID, -1, NOW, NOW.AddDays(-2), NOW.AddDays(-1), GetMasterSecret()};
+    const Key siteKeyExpired{SITE_KEY_ID, SITE_ID, NOW, NOW.AddDays(-2), NOW.AddDays(-1), GetSiteSecret()};
+    client.RefreshJson(KeySetToJson({masterKeyExpired, siteKeyExpired}));
+
+    const auto res = client.Decrypt(advertisingToken, Timestamp::Now());
+    EXPECT_FALSE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::KEYS_NOT_SYNCED, res.GetStatus());
+}
+
+TEST(DecryptionTestsV2, NotAuthorizedForKey)
+{
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+
+    const Key anotherMasterKey{MASTER_KEY_ID + SITE_KEY_ID + 1, -1, NOW, NOW, NOW.AddDays(1), GetMasterSecret()};
+    const Key anotherSiteKey{MASTER_KEY_ID + SITE_KEY_ID + 2, SITE_ID, NOW, NOW, NOW.AddDays(1), GetSiteSecret()};
+    client.RefreshJson(KeySetToJson({anotherMasterKey, anotherSiteKey}));
+
+    const auto res = client.Decrypt(advertisingToken, Timestamp::Now());
+    EXPECT_FALSE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::NOT_AUTHORIZED_FOR_KEY, res.GetStatus());
+}
+
+TEST(DecryptionTestsV2, InvalidPayload)
+{
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({MASTER_KEY, SITE_KEY}));
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, client.Decrypt(advertisingToken.substr(0, advertisingToken.size()-1), NOW).GetStatus());
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, client.Decrypt(advertisingToken.substr(0, advertisingToken.size()-4), NOW).GetStatus());
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, client.Decrypt(advertisingToken.substr(0, 4), NOW).GetStatus());
+}
+
+TEST(DecryptionTestsV2, TokenExpiryAndCustomNow)
+{
+    const Timestamp expiry = NOW.AddDays(-6);
+    const auto params = EncryptTokenParams().WithTokenExpiry(expiry);
+
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({MASTER_KEY, SITE_KEY}));
+    const auto advertisingToken = EncryptTokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY, params);
+
+    auto res = client.Decrypt(advertisingToken, expiry.AddSeconds(1));
+    EXPECT_FALSE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::EXPIRED_TOKEN, res.GetStatus());
+
+    res = client.Decrypt(advertisingToken, expiry.AddSeconds(-1));
+    EXPECT_TRUE(res.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::SUCCESS, res.GetStatus());
+    EXPECT_EQ(EXAMPLE_UID, res.GetUid());
+}
+
+TEST(DecryptDataTestsV2, DecryptData)
+{
+    const std::vector<std::uint8_t> data = {1, 2, 3, 4, 5, 6};
+    const auto encrypted = EncryptDataV2(data, SITE_KEY, 12345, NOW);
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({SITE_KEY}));
+    const auto decrypted = client.DecryptData(encrypted);
+    EXPECT_TRUE(decrypted.IsSuccess());
+    EXPECT_EQ(DecryptionStatus::SUCCESS, decrypted.GetStatus());
+    EXPECT_EQ(data, decrypted.GetDecryptedData());
+    EXPECT_EQ(NOW, decrypted.GetEncryptedAt());
+}
+
+TEST(DecryptDataTestsV2, BadPayloadType)
+{
+    const std::vector<std::uint8_t> data = {1, 2, 3, 4, 5, 6};
+    const auto encrypted = EncryptDataV2(data, SITE_KEY, 12345, NOW);
+    auto encryptedBytes = Base64Decode(encrypted);
+    encryptedBytes[0] = 0;
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({SITE_KEY}));
+    const auto decrypted = client.DecryptData(macaron::Base64::Encode(encryptedBytes));
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD_TYPE, decrypted.GetStatus());
+}
+
+TEST(DecryptDataTestsV2, BadVersion)
+{
+    const std::vector<std::uint8_t> data = {1, 2, 3, 4, 5, 6};
+    const auto encrypted = EncryptDataV2(data, SITE_KEY, 12345, NOW);
+    auto encryptedBytes = Base64Decode(encrypted);
+    encryptedBytes[1] = 0;
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({SITE_KEY}));
+    const auto decrypted = client.DecryptData(macaron::Base64::Encode(encryptedBytes));
+    EXPECT_EQ(DecryptionStatus::VERSION_NOT_SUPPORTED, decrypted.GetStatus());
+}
+
+TEST(DecryptDataTestsV2, BadPayload)
+{
+    const std::vector<std::uint8_t> data = {1, 2, 3, 4, 5, 6};
+    const auto encrypted = EncryptDataV2(data, SITE_KEY, 12345, NOW);
+    const auto encryptedBytes = Base64Decode(encrypted);
+
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({SITE_KEY}));
+
+    auto encryptedBytesLarger = encryptedBytes;
+    encryptedBytesLarger.push_back(1);
+    auto decrypted = client.DecryptData(macaron::Base64::Encode(encryptedBytesLarger));
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, decrypted.GetStatus());
+
+    auto encryptedBytesSmaller = encryptedBytes;
+    encryptedBytesSmaller.pop_back();
+    decrypted = client.DecryptData(macaron::Base64::Encode(encryptedBytesSmaller));
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, decrypted.GetStatus());
+
+    decrypted = client.DecryptData(encrypted.substr(0, 4));
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, decrypted.GetStatus());
+
+    decrypted = client.DecryptData(encrypted + "0");
+    EXPECT_EQ(DecryptionStatus::INVALID_PAYLOAD, decrypted.GetStatus());
+}
+
+TEST(DecryptDataTestsV2, NoDecryptionKey)
+{
+    const std::vector<std::uint8_t> data = {1, 2, 3, 4, 5, 6};
+    const auto encrypted = EncryptDataV2(data, SITE_KEY, 12345, NOW);
+    UID2Client client("ep", "ak", CLIENT_SECRET, IdentityScope::UID2);
+    client.RefreshJson(KeySetToJson({MASTER_KEY}));
+    const auto decrypted = client.DecryptData(encrypted);
+    EXPECT_EQ(DecryptionStatus::NOT_AUTHORIZED_FOR_KEY, decrypted.GetStatus());
+}
+
+std::string KeySetToJson(const std::vector<Key>& keys)
+{
+    std::stringstream ss;
+    ss << "{\"body\": [";
+    bool needComma = false;
+    for (const auto& k : keys)
+    {
+        if (!needComma) needComma = true;
+        else ss << ", ";
+
+        ss << "{\"id\": " << k.id
+           << ", \"site_id\": " << k.siteId
+           << ", \"created\": " << k.created.GetEpochSecond()
+           << ", \"activates\": " << k.activates.GetEpochSecond()
+           << ", \"expires\": " << k.expires.GetEpochSecond()
+           << ", \"secret\": \"" << macaron::Base64::Encode(k.secret) << "\""
+           << "}";
+    }
+    ss << "]}";
+    return ss.str();
+}
+
+std::vector<std::uint8_t> GetMasterSecret()
+{
+    return std::vector<std::uint8_t>(MASTER_SECRET, MASTER_SECRET + sizeof(MASTER_SECRET));
+}
+
+std::vector<std::uint8_t> GetSiteSecret()
+{
+    return std::vector<std::uint8_t>(SITE_SECRET, SITE_SECRET + sizeof(SITE_SECRET));
+}
+
+std::vector<std::uint8_t> MakeKeySecret(std::uint8_t v)
+{
+    return std::vector<std::uint8_t>(sizeof(SITE_SECRET), v);
+}
+
+std::vector<std::uint8_t> Base64Decode(const std::string& str)
+{
+    std::vector<std::uint8_t> result;
+    macaron::Base64::Decode(str, result);
+    return result;
+}


### PR DESCRIPTION
- switch querying keys to use v2 APIs
- switch DEP blob encryption to v3 format
- add support for decrypting v3 advertising tokens and DEP blobs
- make site id and identity established timestamp available even if advertising token is expired
- add support for EUID and phone number