### PR TITLE
Add CA certificate path customization for HTTPS connections

### DIFF
--- a/lib/uid2client.cpp
+++ b/lib/uid2client.cpp
@@ -5,7 +5,7 @@
 #include "keyparser.h"
 #include "uid2encryption.h"
 #include "version.h"
-
+#include <cstdlib> // For getenv
 #include <uid2/uid2client.h>
 
 #include <mutex>
@@ -27,7 +27,16 @@ struct UID2Client::Impl {
     {
         macaron::Base64::Decode(secretKey, this->secretKey_);
 
-        if (endpoint_.find("https") != 0) {
+        if (endpoint_.find("https") == 0) {
+            // Check if the CA_CERT_FILE_PATH/CA_CERT_DIR_PATH environment variables are set
+            const char* caCertFilePath = std::getenv("CA_CERT_FILE_PATH");
+            const char* caCertDirPath = std::getenv("CA_CERT_DIR_PATH");
+
+            // Use CA_CERT_FILE_PATH/CA_CERT_DIR_PATH if set, otherwise fallback to the default path
+            httpClient_.set_ca_cert_path(caCertFilePath ? caCertFilePath : "/etc/ssl/certs/ca-certificates.crt",
+                                            caCertDirPath ? caCertDirPath : "/etc/ssl/certs/");
+            httpClient_.enable_server_certificate_verification(true);
+        } else {
             // TODO: non-https endpoint warning
         }
 


### PR DESCRIPTION
This commit introduces the ability to customize the CA certificate path used by the UID2Client when establishing HTTPS connections. It enables setting the certificate file and directory path through the environment variables CA_CERT_FILE_PATH and CA_CERT_DIR_PATH, respectively. If these variables are not set, the client defaults to using standard paths for CA certificates.

Background:
While using uid2-client lib with OpenSSL 1.1.1k, Refresh was failing with "Failed to refresh keys: error code: 10, verify error: unable to get local issuer certificate" error. Same issue was observed when executing `openssl s_client -connect global.prod.uidapi.com:443 -showcerts`, indicating a problem with locating or validating the CA certificate. However, when specifying the certificate path directly using the `-CApath` or `-CAfile` option in OpenSSL, the verification succeeded. This behavior highlighted the need for a way to specify the CA certificate path in the UID2Client.

Key Changes:
- Added checks to set the CA certificate file and directory paths based on the environment variables CA_CERT_FILE_PATH and CA_CERT_DIR_PATH.
- Set the default CA certificate file path to "/etc/ssl/certs/ca-certificates.crt" and the directory path to "/etc/ssl/certs/" if the environment variables are not set.

By allowing the CA certificate paths to be customized, this change addresses the verification issue encountered with OpenSSL 1.1.1k, providing flexibility and configurability for environments with custom CA certificates or when running in containers or non-standard environments.