### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/workflows/dev-docker-image.yml
+++ b/.github/workflows/dev-docker-image.yml
@@ -9,6 +9,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Build development docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
       with:
         push: false


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)